### PR TITLE
fix: add use client banner to the build files

### DIFF
--- a/packages/react/tsup.config.ts
+++ b/packages/react/tsup.config.ts
@@ -11,4 +11,7 @@ export default defineConfig({
   minify: false,
   target: 'es2020',
   external: ['react', 'react-dom'], // Mark React as external
+  banner: {
+    js: `"use client";`,
+  },
 })


### PR DESCRIPTION
it preserves the `use client` banner in the build files so that it can be used in nextjs apps without having to create a separate provider wrapper client component.