### PR TITLE
feat: update supa prefix to supaship

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,9 +16,9 @@ More packages will be added in the future to support additional platforms and fr
 ### JavaScript SDK
 
 ```javascript
-import { SupaClient } from '@supashiphq/javascript-sdk'
+import { SupashipClient } from '@supashiphq/javascript-sdk'
 
-const client = new SupaClient({
+const client = new SupashipClient({
   sdkKey: 'sdk-key',
   environment: 'production',
   context: {

--- a/packages/javascript/README.md
+++ b/packages/javascript/README.md
@@ -15,7 +15,7 @@ pnpm add @supashiphq/javascript-sdk
 ## Quick Start
 
 ```typescript
-import { SupaClient, FeaturesWithFallbacks } from '@supashiphq/javascript-sdk'
+import { SupashipClient, FeaturesWithFallbacks } from '@supashiphq/javascript-sdk'
 
 // Define your features with fallback values
 const features = {
@@ -28,7 +28,7 @@ const features = {
 } satisfies FeaturesWithFallbacks
 
 // Create client with features
-const client = new SupaClient({
+const client = new SupashipClient({
   sdkKey: 'your-sdk-key',
   environment: 'production',
   features,
@@ -95,7 +95,7 @@ const features: FeaturesWithFallbacks = {
   },
 }
 
-const client = new SupaClient({
+const client = new SupashipClient({
   sdkKey: 'your-sdk-key',
   environment: 'production',
   features,
@@ -111,12 +111,12 @@ const value = await client.getFeature('unknown-feature')
 
 ## API Reference
 
-### SupaClient
+### SupashipClient
 
 #### Constructor
 
 ```typescript
-new SupaClient(config: SupaClientConfig)
+new SupashipClient(config: SupashipClientConfig)
 ```
 
 **Configuration Options:**
@@ -129,7 +129,7 @@ new SupaClient(config: SupaClientConfig)
 | `context`                    | `FeatureContext`        | Yes      | Default context for feature evaluation                                             |
 | `sensitiveContextProperties` | `string[]`              | No       | Hash sensitive context properties such as PII on the client before sending to Edge |
 | `networkConfig`              | `NetworkConfig`         | No       | Network settings (endpoints, retry, timeout, custom fetch)                         |
-| `plugins`                    | `SupaPlugin[]`          | No       | Plugins for observability, caching, etc.                                           |
+| `plugins`                    | `SupashipPlugin[]`      | No       | Plugins for observability, caching, etc.                                           |
 
 **Feature Context:**
 
@@ -142,7 +142,7 @@ new SupaClient(config: SupaClientConfig)
 Use `sensitiveContextProperties` to hash selected context property values on the client before requests are sent to Edge.
 
 ```typescript
-const client = new SupaClient({
+const client = new SupashipClient({
   sdkKey: 'your-sdk-key',
   environment: 'production',
   features,
@@ -199,7 +199,7 @@ const features = {
   'theme-config': { primary: '#007bff' },
 } satisfies FeaturesWithFallbacks
 
-const client = new SupaClient({
+const client = new SupashipClient({
   sdkKey: 'key',
   environment: 'production',
   features,
@@ -245,7 +245,7 @@ const features = {
   'beta-mode': false,
 } satisfies FeaturesWithFallbacks
 
-const client = new SupaClient({
+const client = new SupashipClient({
   sdkKey: 'key',
   environment: 'prod',
   features,
@@ -348,10 +348,10 @@ export const features = {
 } satisfies FeaturesWithFallbacks
 
 // client.ts
-import { SupaClient } from '@supashiphq/javascript-sdk'
+import { SupashipClient } from '@supashiphq/javascript-sdk'
 import { features } from './features'
 
-export const client = new SupaClient({
+export const client = new SupashipClient({
   sdkKey: process.env.SUPASHIP_SDK_KEY!,
   environment: process.env.ENVIRONMENT!,
   features,
@@ -382,7 +382,7 @@ const features: FeaturesWithFallbacks = {
   },
 }
 
-const client = new SupaClient({
+const client = new SupashipClient({
   sdkKey: 'key',
   environment: 'prod',
   features,
@@ -400,7 +400,7 @@ const theme = config.theme // ✅ Type-safe, inferred as 'light' literal
 ### 3. Use Context for Targeting
 
 ```typescript
-const client = new SupaClient({
+const client = new SupashipClient({
   sdkKey: 'your-sdk-key',
   environment: 'production',
   features,
@@ -447,7 +447,7 @@ Visual toolbar for local development and testing.
 **✨ Auto-enabled in browser environments!** The toolbar is automatically enabled in browsers with `enabled: 'auto'` (shows only on localhost). No manual configuration needed!
 
 ```typescript
-import { SupaClient, FeaturesWithFallbacks } from '@supashiphq/javascript-sdk'
+import { SupashipClient, FeaturesWithFallbacks } from '@supashiphq/javascript-sdk'
 
 const features = {
   'new-ui': false,
@@ -455,7 +455,7 @@ const features = {
 } satisfies FeaturesWithFallbacks
 
 // ✅ Automatic (recommended) - Toolbar auto-enabled in browser with 'auto' mode
-const client = new SupaClient({
+const client = new SupashipClient({
   sdkKey: 'your-sdk-key',
   environment: 'development',
   features,
@@ -463,7 +463,7 @@ const client = new SupaClient({
 })
 
 // 🎨 Custom configuration
-const client = new SupaClient({
+const client = new SupashipClient({
   sdkKey: 'your-sdk-key',
   environment: 'development',
   features,
@@ -478,7 +478,7 @@ const client = new SupaClient({
 })
 
 // ❌ Opt-out (disable toolbar)
-const client = new SupaClient({
+const client = new SupashipClient({
   sdkKey: 'your-sdk-key',
   environment: 'production',
   features,
@@ -509,7 +509,7 @@ For React applications, use our dedicated React SDK which provides hooks and com
 
 ```typescript
 import express from 'express'
-import { SupaClient, FeaturesWithFallbacks } from '@supashiphq/javascript-sdk'
+import { SupashipClient, FeaturesWithFallbacks } from '@supashiphq/javascript-sdk'
 
 const features = {
   'new-api': false,
@@ -517,7 +517,7 @@ const features = {
   'rate-limit': { maxRequests: 100, windowMs: 60000 },
 } satisfies FeaturesWithFallbacks
 
-const featureClient = new SupaClient({
+const featureClient = new SupashipClient({
   sdkKey: process.env.SUPASHIP_SDK_KEY!,
   environment: 'production',
   features,
@@ -552,7 +552,7 @@ app.get('/api/user-features/:userId', async (req, res) => {
 
 ```typescript
 // plugins/feature-flags.ts
-import { SupaClient, FeaturesWithFallbacks } from '@supashiphq/javascript-sdk'
+import { SupashipClient, FeaturesWithFallbacks } from '@supashiphq/javascript-sdk'
 
 const features = {
   'new-nav': false,
@@ -560,7 +560,7 @@ const features = {
   'premium-content': false,
 } satisfies FeaturesWithFallbacks
 
-const client = new SupaClient({
+const client = new SupashipClient({
   sdkKey: import.meta.env.VITE_SUPASHIP_SDK_KEY,
   environment: 'production',
   features,
@@ -577,9 +577,9 @@ export default {
 // components/MyComponent.vue
 <script setup lang="ts">
 import { inject, ref, onMounted } from 'vue'
-import type { SupaClient } from '@supashiphq/javascript-sdk'
+import type { SupashipClient } from '@supashiphq/javascript-sdk'
 
-const featureFlags = inject<SupaClient>('featureFlags')!
+const featureFlags = inject<SupashipClient>('featureFlags')!
 const showNewNav = ref(false)
 const darkMode = ref(false)
 
@@ -602,7 +602,7 @@ onMounted(async () => {
 ```typescript
 // feature-flag.service.ts
 import { Injectable } from '@angular/core'
-import { SupaClient, FeaturesWithFallbacks } from '@supashiphq/javascript-sdk'
+import { SupashipClient, FeaturesWithFallbacks } from '@supashiphq/javascript-sdk'
 import { environment } from '../environments/environment'
 
 const features = {
@@ -615,10 +615,10 @@ const features = {
   providedIn: 'root',
 })
 export class FeatureFlagService {
-  private client: SupaClient
+  private client: SupashipClient
 
   constructor() {
-    this.client = new SupaClient({
+    this.client = new SupashipClient({
       sdkKey: environment.SUPASHIP_SDK_KEY,
       environment: 'production',
       features,

--- a/packages/javascript/src/__tests__/client.test.ts
+++ b/packages/javascript/src/__tests__/client.test.ts
@@ -1,4 +1,4 @@
-import { SupaClient } from '../client'
+import { SupashipClient } from '../client'
 import { FeatureContext, FeaturesWithFallbacks } from '../types'
 import '../types/jest.d.ts'
 import { createHash } from 'node:crypto'
@@ -27,7 +27,7 @@ jest.mock('../utils', () => ({
   },
 }))
 
-describe('SupaClient', () => {
+describe('SupashipClient', () => {
   const mockSdkKey = 'test-sdk-key'
   const mockBaseUrl = 'https://test-api.com'
   const testFeatures = {
@@ -35,10 +35,10 @@ describe('SupaClient', () => {
     feature1: false as boolean,
     feature2: true as boolean,
   } satisfies FeaturesWithFallbacks
-  let client: SupaClient<typeof testFeatures>
+  let client: SupashipClient<typeof testFeatures>
 
   beforeEach((): void => {
-    client = new SupaClient({
+    client = new SupashipClient({
       sdkKey: mockSdkKey,
       environment: 'test-environment',
       networkConfig: {
@@ -52,7 +52,7 @@ describe('SupaClient', () => {
 
   describe('constructor and configuration', () => {
     it('should use default featuresAPIUrl when not provided', (): void => {
-      const client = new SupaClient({
+      const client = new SupashipClient({
         sdkKey: 'test',
         environment: 'test-environment',
         context: {},
@@ -62,7 +62,7 @@ describe('SupaClient', () => {
     })
 
     it('should use default retry configuration', (): void => {
-      const client = new SupaClient({
+      const client = new SupashipClient({
         sdkKey: 'test',
         environment: 'test-environment',
         features: {} satisfies FeaturesWithFallbacks,
@@ -74,7 +74,7 @@ describe('SupaClient', () => {
     })
 
     it('should use custom retry configuration', (): void => {
-      const client = new SupaClient({
+      const client = new SupashipClient({
         sdkKey: 'test',
         environment: 'test-environment',
         features: {} satisfies FeaturesWithFallbacks,
@@ -89,7 +89,7 @@ describe('SupaClient', () => {
     })
 
     it('should handle empty plugins array', (): void => {
-      const client = new SupaClient({
+      const client = new SupashipClient({
         sdkKey: 'test',
         environment: 'test-environment',
         features: {} satisfies FeaturesWithFallbacks,
@@ -100,7 +100,7 @@ describe('SupaClient', () => {
     })
 
     it('should handle undefined plugins', (): void => {
-      const client = new SupaClient({
+      const client = new SupashipClient({
         sdkKey: 'test',
         environment: 'test-environment',
         features: {} satisfies FeaturesWithFallbacks,
@@ -112,7 +112,7 @@ describe('SupaClient', () => {
 
   describe('updateContext', () => {
     it('should merge context by default', (): void => {
-      const testClient = new SupaClient({
+      const testClient = new SupashipClient({
         sdkKey: mockSdkKey,
         environment: 'test-environment',
         features: testFeatures,
@@ -130,7 +130,7 @@ describe('SupaClient', () => {
     })
 
     it('should replace context when mergeWithExisting is false', (): void => {
-      const testClient = new SupaClient({
+      const testClient = new SupashipClient({
         sdkKey: mockSdkKey,
         environment: 'test-environment',
         features: testFeatures,
@@ -159,7 +159,7 @@ describe('SupaClient', () => {
         onContextUpdate: jest.fn(),
       }
 
-      const testClient = new SupaClient({
+      const testClient = new SupashipClient({
         sdkKey: mockSdkKey,
         environment: 'test-environment',
         features: testFeatures,
@@ -261,7 +261,7 @@ describe('SupaClient', () => {
         onFallbackUsed: jest.fn(),
       }
 
-      const testClient = new SupaClient({
+      const testClient = new SupashipClient({
         sdkKey: mockSdkKey,
         environment: 'test-environment',
         features: testFeatures,
@@ -284,7 +284,7 @@ describe('SupaClient', () => {
         onError: jest.fn().mockResolvedValue(undefined),
         onFallbackUsed: jest.fn().mockResolvedValue(undefined),
       }
-      const testClient = new SupaClient({
+      const testClient = new SupashipClient({
         sdkKey: mockSdkKey,
         environment: 'test-environment',
         features: { testFeature: null } satisfies FeaturesWithFallbacks,
@@ -323,7 +323,7 @@ describe('SupaClient', () => {
         onContextUpdate: jest.fn(),
       }
 
-      const testClient = new SupaClient({
+      const testClient = new SupashipClient({
         sdkKey: mockSdkKey,
         environment: 'test-environment',
         features: { feature1: null } satisfies FeaturesWithFallbacks,
@@ -362,7 +362,7 @@ describe('SupaClient', () => {
         onFallbackUsed: jest.fn(),
       }
 
-      const testClient = new SupaClient({
+      const testClient = new SupashipClient({
         sdkKey: mockSdkKey,
         environment: 'test-environment',
         features: {
@@ -392,7 +392,7 @@ describe('SupaClient', () => {
         afterResponse: jest.fn().mockResolvedValue(undefined),
       }
 
-      const testClient = new SupaClient({
+      const testClient = new SupashipClient({
         sdkKey: mockSdkKey,
         environment: 'test-environment',
         features: { feature1: null } satisfies FeaturesWithFallbacks,
@@ -416,7 +416,7 @@ describe('SupaClient', () => {
 
     it('should return fallback values when no fetch implementation is available', async (): Promise<void> => {
       const originalFetch = global.fetch
-      const testClient = new SupaClient({
+      const testClient = new SupashipClient({
         sdkKey: mockSdkKey,
         environment: 'test-environment',
         features: { feature1: false as boolean } satisfies FeaturesWithFallbacks,
@@ -439,7 +439,7 @@ describe('SupaClient', () => {
         ok: true,
         json: () => Promise.resolve({ features: { feature1: { variation: true } } }),
       } as MockResponse)
-      const testClient = new SupaClient({
+      const testClient = new SupashipClient({
         sdkKey: mockSdkKey,
         environment: 'test-environment',
         features: { feature1: null } satisfies FeaturesWithFallbacks,
@@ -471,7 +471,7 @@ describe('SupaClient', () => {
         ok: true,
         json: () => Promise.resolve({ features: { feature1: { variation: true } } }),
       } as MockResponse)
-      const testClient = new SupaClient({
+      const testClient = new SupashipClient({
         sdkKey: mockSdkKey,
         environment: 'test-environment',
         features: { feature1: null } satisfies FeaturesWithFallbacks,
@@ -522,7 +522,7 @@ describe('SupaClient', () => {
     })
 
     it('should work with retry disabled', async (): Promise<void> => {
-      const testClient = new SupaClient({
+      const testClient = new SupashipClient({
         sdkKey: mockSdkKey,
         environment: 'test-environment',
         features: { testFeature: null } satisfies FeaturesWithFallbacks,
@@ -551,7 +551,7 @@ describe('SupaClient', () => {
         onError: jest.fn().mockResolvedValue(undefined),
       }
 
-      const testClient = new SupaClient({
+      const testClient = new SupashipClient({
         sdkKey: mockSdkKey,
         environment: 'test-environment',
         features: { testFeature: null } satisfies FeaturesWithFallbacks,

--- a/packages/javascript/src/client.ts
+++ b/packages/javascript/src/client.ts
@@ -1,5 +1,5 @@
 import {
-  SupaClientConfig,
+  SupashipClientConfig,
   FeatureContext,
   FeatureValue,
   NetworkConfig,
@@ -7,8 +7,8 @@ import {
   FeaturesWithFallbacks,
 } from './types'
 import { retry } from './utils'
-import { SupaPlugin } from './plugins/types'
-import { SupaToolbarPlugin } from './plugins/toolbar-plugin'
+import { SupashipPlugin } from './plugins/types'
+import { SupashipToolbarPlugin } from './plugins/toolbar-plugin'
 import { DEFAULT_FEATURES_URL, DEFAULT_EVENTS_URL } from './constants'
 
 type RequiredRetryConfig = Required<NonNullable<NetworkConfig['retry']>>
@@ -19,11 +19,11 @@ type ResolvedNetworkConfig = {
   requestTimeoutMs: number
 }
 
-export class SupaClient<TFeatures extends FeaturesWithFallbacks> {
+export class SupashipClient<TFeatures extends FeaturesWithFallbacks> {
   private sdkKey: string
   private environment: string
   private defaultContext?: FeatureContext
-  private plugins: SupaPlugin[]
+  private plugins: SupashipPlugin[]
   private featureDefinitions: Features<TFeatures>
   private clientId: string
   private sensitiveContextProperties: Set<string>
@@ -31,7 +31,7 @@ export class SupaClient<TFeatures extends FeaturesWithFallbacks> {
   private fetchFn?: (input: RequestInfo | URL, init?: RequestInit) => Promise<Response>
   private networkConfig: ResolvedNetworkConfig
 
-  constructor(config: SupaClientConfig & { features: TFeatures }) {
+  constructor(config: SupashipClientConfig & { features: TFeatures }) {
     this.sdkKey = config.sdkKey
     this.environment = config.environment
     this.defaultContext = config.context
@@ -127,7 +127,9 @@ export class SupaClient<TFeatures extends FeaturesWithFallbacks> {
   /**
    * Initialize plugins with automatic toolbar plugin in browser environments
    */
-  private initializePlugins(config: SupaClientConfig & { features: TFeatures }): SupaPlugin[] {
+  private initializePlugins(
+    config: SupashipClientConfig & { features: TFeatures }
+  ): SupashipPlugin[] {
     const plugins = config.plugins || []
 
     // Check if we're in a browser environment
@@ -146,7 +148,7 @@ export class SupaClient<TFeatures extends FeaturesWithFallbacks> {
       if (!hasToolbarPlugin) {
         // Add toolbar with user config or defaults
         const toolbarConfig = config.toolbar || { enabled: 'auto' }
-        const toolbarPlugin = new SupaToolbarPlugin(toolbarConfig)
+        const toolbarPlugin = new SupashipToolbarPlugin(toolbarConfig)
         return [toolbarPlugin, ...plugins]
       }
     }

--- a/packages/javascript/src/index.ts
+++ b/packages/javascript/src/index.ts
@@ -1,12 +1,12 @@
 export type * from './types'
-export { SupaClient } from './client'
-export type { SupaPlugin, SupaPluginConfig } from './plugins/types'
-export { SupaToolbarPlugin as ToolbarPlugin } from './plugins/toolbar-plugin'
+export { SupashipClient } from './client'
+export type { SupashipPlugin, SupashipPluginConfig } from './plugins/types'
+export { SupashipToolbarPlugin as ToolbarPlugin } from './plugins/toolbar-plugin'
 export type {
-  SupaToolbarPluginConfig,
-  SupaToolbarPosition,
-  SupaToolbarOverrideChange,
-  SupaToolbarOverrideChangeCallback,
+  SupashipToolbarPluginConfig,
+  SupashipToolbarPosition,
+  SupashipToolbarOverrideChange,
+  SupashipToolbarOverrideChangeCallback,
 } from './plugins/toolbar-plugin'
 // export { LoggingPlugin } from "./plugins/logging-plugin";
 // export { CachingPlugin } from "./plugins/caching-plugin";

--- a/packages/javascript/src/plugins/analytics-plugin.ts
+++ b/packages/javascript/src/plugins/analytics-plugin.ts
@@ -1,7 +1,7 @@
-import { SupaPlugin, SupaPluginConfig } from './types'
+import { SupashipPlugin, SupashipPluginConfig } from './types'
 import { FeatureContext, FeatureValue } from '../types'
 
-export interface AnalyticsPluginConfig extends SupaPluginConfig {
+export interface AnalyticsPluginConfig extends SupashipPluginConfig {
   endpoint?: string
   batchSize?: number
   flushInterval?: number
@@ -15,7 +15,7 @@ interface AnalyticsEvent {
   timestamp: number
 }
 
-export class AnalyticsPlugin implements SupaPlugin {
+export class AnalyticsPlugin implements SupashipPlugin {
   name = 'analytics'
   private enabled: boolean
   private endpoint: string

--- a/packages/javascript/src/plugins/caching-plugin.ts
+++ b/packages/javascript/src/plugins/caching-plugin.ts
@@ -1,4 +1,4 @@
-import { SupaPlugin, SupaPluginConfig } from './types'
+import { SupashipPlugin, SupashipPluginConfig } from './types'
 import { FeatureContext, FeatureValue } from '../types'
 
 export interface CacheEntry {
@@ -7,12 +7,12 @@ export interface CacheEntry {
   ttl: number
 }
 
-export interface CachingPluginConfig extends SupaPluginConfig {
+export interface CachingPluginConfig extends SupashipPluginConfig {
   storage?: 'memory' | 'localStorage' | 'sessionStorage'
   ttl?: number
 }
 
-export class CachingPlugin implements SupaPlugin {
+export class CachingPlugin implements SupashipPlugin {
   name = 'caching'
   private cache: Cache
   private enabled: boolean

--- a/packages/javascript/src/plugins/logging-plugin.ts
+++ b/packages/javascript/src/plugins/logging-plugin.ts
@@ -1,4 +1,4 @@
-import { SupaPlugin, SupaPluginConfig } from './types'
+import { SupashipPlugin, SupashipPluginConfig } from './types'
 import { FeatureContext, FeatureValue } from '../types'
 
 export interface Logger {
@@ -8,11 +8,11 @@ export interface Logger {
   error(message: string, ...args: unknown[]): void
 }
 
-export interface LoggingPluginConfig extends SupaPluginConfig {
+export interface LoggingPluginConfig extends SupashipPluginConfig {
   level?: 'debug' | 'info' | 'warn' | 'error'
 }
 
-export class LoggingPlugin implements SupaPlugin {
+export class LoggingPlugin implements SupashipPlugin {
   name = 'logging'
   private logger: DefaultLogger
   private enabled: boolean

--- a/packages/javascript/src/plugins/observability-plugin.ts
+++ b/packages/javascript/src/plugins/observability-plugin.ts
@@ -1,7 +1,7 @@
-import { SupaPlugin, SupaPluginConfig } from './types'
+import { SupashipPlugin, SupashipPluginConfig } from './types'
 import { FeatureContext, FeatureValue } from '../types'
 
-export interface ObservabilityPluginConfig extends SupaPluginConfig {
+export interface ObservabilityPluginConfig extends SupashipPluginConfig {
   metricsEndpoint?: string
   includeTimings?: boolean
   includePayloads?: boolean
@@ -13,7 +13,7 @@ interface MetricEvent {
   data: Record<string, unknown>
 }
 
-export class ObservabilityPlugin implements SupaPlugin {
+export class ObservabilityPlugin implements SupashipPlugin {
   name = 'observability'
   private enabled: boolean
   metricsEndpoint: string

--- a/packages/javascript/src/plugins/toolbar-plugin.ts
+++ b/packages/javascript/src/plugins/toolbar-plugin.ts
@@ -1,28 +1,28 @@
-import { SupaPlugin, SupaPluginConfig } from './types'
+import { SupashipPlugin, SupashipPluginConfig } from './types'
 import { FeatureContext, FeatureValue } from '../types'
 
-export interface SupaToolbarPosition {
+export interface SupashipToolbarPosition {
   placement?: 'bottom-left' | 'bottom-right' | 'top-left' | 'top-right'
   offset?: { x: string; y: string }
 }
 
-export type SupaToolbarOverrideChange = {
+export type SupashipToolbarOverrideChange = {
   feature: string
   value: FeatureValue
 }
 
-export type SupaToolbarOverrideChangeCallback = (
-  featureOverride: SupaToolbarOverrideChange,
+export type SupashipToolbarOverrideChangeCallback = (
+  featureOverride: SupashipToolbarOverrideChange,
   allOverrides: Record<string, FeatureValue>
 ) => void
 
-export interface SupaToolbarPluginConfig extends Omit<SupaPluginConfig, 'enabled'> {
+export interface SupashipToolbarPluginConfig extends Omit<SupashipPluginConfig, 'enabled'> {
   enabled?: boolean | 'auto' // auto means show only on localhost
-  position?: SupaToolbarPosition
-  onOverrideChange?: SupaToolbarOverrideChangeCallback
+  position?: SupashipToolbarPosition
+  onOverrideChange?: SupashipToolbarOverrideChangeCallback
 }
 
-interface SupaToolbarState {
+interface SupashipToolbarState {
   overrides: Record<string, FeatureValue>
   features: Set<string>
   featureValues: Record<string, FeatureValue>
@@ -39,18 +39,18 @@ const NO_FEATURES_MESSAGE = `No feature flags configured in the client.`
  * Toolbar plugin for local feature flag testing
  * Provides a visual interface to override feature flags during development
  */
-export class SupaToolbarPlugin implements SupaPlugin {
+export class SupashipToolbarPlugin implements SupashipPlugin {
   name = 'toolbar-plugin'
   private config: {
     enabled: boolean | 'auto'
-    position: Required<SupaToolbarPosition>
-    onOverrideChange?: SupaToolbarOverrideChangeCallback
+    position: Required<SupashipToolbarPosition>
+    onOverrideChange?: SupashipToolbarOverrideChangeCallback
   }
-  private state: SupaToolbarState
+  private state: SupashipToolbarState
   private clientId?: string
   private storageKey: string = DEFAULT_STORAGE_KEY
 
-  constructor(config: SupaToolbarPluginConfig = {}) {
+  constructor(config: SupashipToolbarPluginConfig = {}) {
     this.config = {
       enabled: config.enabled ?? 'auto',
       position: {

--- a/packages/javascript/src/plugins/types.ts
+++ b/packages/javascript/src/plugins/types.ts
@@ -1,6 +1,6 @@
 import { FeatureContext, FeatureValue } from '../types'
 
-export interface SupaPluginConfig {
+export interface SupashipPluginConfig {
   enabled?: boolean
 }
 interface Plugin {
@@ -9,7 +9,7 @@ interface Plugin {
   // cleanup?(): Promise<void>
 }
 
-export interface SupaPlugin extends Plugin {
+export interface SupashipPlugin extends Plugin {
   // Lifecycle hooks
   onInit?(params: {
     clientId: string

--- a/packages/javascript/src/types.ts
+++ b/packages/javascript/src/types.ts
@@ -1,9 +1,9 @@
-import { SupaPlugin } from './plugins/types'
-import { SupaToolbarPluginConfig } from './plugins/toolbar-plugin'
+import { SupashipPlugin } from './plugins/types'
+import { SupashipToolbarPluginConfig } from './plugins/toolbar-plugin'
 
-export type { SupaToolbarPluginConfig } from './plugins/toolbar-plugin'
+export type { SupashipToolbarPluginConfig } from './plugins/toolbar-plugin'
 
-export interface SupaClientConfig {
+export interface SupashipClientConfig {
   /**
    * SDK key used to authenticate requests to Supaship services.
    * Typically created in your project settings.
@@ -37,7 +37,7 @@ export interface SupaClientConfig {
   /**
    * Optional plugins to observe or augment client behavior.
    */
-  plugins?: SupaPlugin[]
+  plugins?: SupashipPlugin[]
   /**
    * Toolbar plugin configuration (browser only).
    * - `false`: Disable toolbar (opt-out)
@@ -46,7 +46,7 @@ export interface SupaClientConfig {
    *
    * Default: Enabled in browser with 'auto' mode (shows only on localhost)
    */
-  toolbar?: false | SupaToolbarPluginConfig
+  toolbar?: false | SupashipToolbarPluginConfig
 }
 
 export interface FeatureContext {
@@ -118,7 +118,7 @@ export type WidenFeatures<T extends Record<string, FeatureValue>> = {
  * ⚠️ IMPORTANT: Use with `satisfies` operator, NOT type annotation
  *
  * Type representing feature flag definitions with their fallback values.
- * Used to configure the SupaClient with feature flags.
+ * Used to configure the SupashipClient with feature flags.
  *
  * **Why `satisfies` over type annotation:**
  * - ✅ `satisfies` preserves exact types ('feature-flag' stays 'feature-flag')

--- a/packages/react-core/README.md
+++ b/packages/react-core/README.md
@@ -9,7 +9,7 @@ Shared React layer for [Supaship](https://supashp.com): provider wiring, feature
 | Web / React / NextJS | `@supashiphq/react-sdk`        | [npm](https://www.npmjs.com/package/@supashiphq/react-sdk)        |
 | React Native         | `@supashiphq/react-native-sdk` | [npm](https://www.npmjs.com/package/@supashiphq/react-native-sdk) |
 
-Install the SDK that matches your stack. Those packages re-export the API you need (`SupaProvider`, `useFeature`, etc.) and pin the correct focus/refetch behavior (browser vs app lifecycle).
+Install the SDK that matches your stack. Those packages re-export the API you need (`SupashipProvider`, `useFeature`, etc.) and pin the correct focus/refetch behavior (browser vs app lifecycle).
 
 The `focus-native` export is for React Native apps only; it imports `AppState` from `react-native`, which must be supplied by your app (not listed as a peer here to keep this package’s dev graph free of the full native SDK).
 

--- a/packages/react-core/src/create-supaship-react.tsx
+++ b/packages/react-core/src/create-supaship-react.tsx
@@ -8,43 +8,43 @@ import React, {
   useEffect,
 } from 'react'
 import {
-  SupaClient,
-  SupaClientConfig as SupaProviderConfig,
+  SupashipClient,
+  SupashipClientConfig as SupashipProviderConfig,
   FeatureContext,
   FeatureValue,
   Features,
-  SupaToolbarOverrideChange,
-  SupaToolbarPluginConfig,
+  SupashipToolbarOverrideChange,
+  SupashipToolbarPluginConfig,
 } from '@supashiphq/javascript-sdk'
 import type { UseFocusRefetchEffect } from './focus-types'
 import { createFeatureHooks } from './feature-hooks'
 import { createQueryHooks } from './query-hooks-factory'
 
 /** @internal Narrow feature map for context typing */
-export type SupaGenericFeatures = Features<Record<string, FeatureValue>>
+export type SupashipGenericFeatures = Features<Record<string, FeatureValue>>
 
-interface SupaContextValue<TFeatures extends Features<Record<string, FeatureValue>>> {
-  client: SupaClient<TFeatures>
+interface SupashipContextValue<TFeatures extends Features<Record<string, FeatureValue>>> {
+  client: SupashipClient<TFeatures>
   updateContext: (context: FeatureContext, mergeWithExisting?: boolean) => void
   getContext: () => FeatureContext | undefined
 }
 
-const DEFAULT_TOOLBAR_CONFIG: SupaToolbarPluginConfig = { enabled: 'auto' }
+const DEFAULT_TOOLBAR_CONFIG: SupashipToolbarPluginConfig = { enabled: 'auto' }
 
 // eslint-disable-next-line @typescript-eslint/explicit-function-return-type -- return bundles provider, hooks, and query API
 export function createSupashipReact(useFocusRefetchEffect: UseFocusRefetchEffect) {
   const { useQuery, useQueryClient, queryCache, QueryClient, getInitialQueryState } =
     createQueryHooks(useFocusRefetchEffect)
 
-  const SupaContext = createContext<SupaContextValue<SupaGenericFeatures> | null>(null)
+  const SupashipContext = createContext<SupashipContextValue<SupashipGenericFeatures> | null>(null)
 
-  function SupaProvider<TFeatures extends Features<Record<string, FeatureValue>>>({
+  function SupashipProvider<TFeatures extends Features<Record<string, FeatureValue>>>({
     config,
     toolbar,
     children,
   }: {
-    config: Omit<SupaProviderConfig, 'plugins' | 'toolbar'> & { features: TFeatures }
-    toolbar?: SupaToolbarPluginConfig | boolean
+    config: Omit<SupashipProviderConfig, 'plugins' | 'toolbar'> & { features: TFeatures }
+    toolbar?: SupashipToolbarPluginConfig | boolean
     children: ReactNode
   }): React.JSX.Element {
     const queryClient = useQueryClient()
@@ -52,7 +52,7 @@ export function createSupashipReact(useFocusRefetchEffect: UseFocusRefetchEffect
 
     const handleOverrideChange = useCallback(
       (
-        featureOverride: SupaToolbarOverrideChange,
+        featureOverride: SupashipToolbarOverrideChange,
         allOverrides: Record<string, FeatureValue>
       ): void => {
         if (typeof effectiveToolbar === 'object' && effectiveToolbar.onOverrideChange) {
@@ -67,7 +67,7 @@ export function createSupashipReact(useFocusRefetchEffect: UseFocusRefetchEffect
       [effectiveToolbar, queryClient]
     )
 
-    const clientRef = useRef<SupaClient<TFeatures> | null>(null)
+    const clientRef = useRef<SupashipClient<TFeatures> | null>(null)
 
     if (!clientRef.current) {
       const toolbarConfig =
@@ -78,7 +78,7 @@ export function createSupashipReact(useFocusRefetchEffect: UseFocusRefetchEffect
               onOverrideChange: handleOverrideChange,
             }
 
-      clientRef.current = new SupaClient<TFeatures>({
+      clientRef.current = new SupashipClient<TFeatures>({
         ...config,
         toolbar: toolbarConfig,
       })
@@ -125,26 +125,26 @@ export function createSupashipReact(useFocusRefetchEffect: UseFocusRefetchEffect
       [client, updateContext, getContext]
     )
 
-    return <SupaContext.Provider value={contextValue}>{children}</SupaContext.Provider>
+    return <SupashipContext.Provider value={contextValue}>{children}</SupashipContext.Provider>
   }
 
   function useClient<
     TFeatures extends Features<Record<string, FeatureValue>>,
-  >(): SupaClient<TFeatures> {
-    const context = useContext(SupaContext)
+  >(): SupashipClient<TFeatures> {
+    const context = useContext(SupashipContext)
     if (!context) {
-      throw new Error('useClient must be used within a SupaProvider')
+      throw new Error('useClient must be used within a SupashipProvider')
     }
-    return context.client as SupaClient<TFeatures>
+    return context.client as SupashipClient<TFeatures>
   }
 
   function useFeatureContext(): {
     updateContext: (context: FeatureContext, mergeWithExisting?: boolean) => void
     getContext: () => FeatureContext | undefined
   } {
-    const context = useContext(SupaContext)
+    const context = useContext(SupashipContext)
     if (!context) {
-      throw new Error('useFeatureContext must be used within a SupaProvider')
+      throw new Error('useFeatureContext must be used within a SupashipProvider')
     }
     return {
       updateContext: context.updateContext,
@@ -155,7 +155,7 @@ export function createSupashipReact(useFocusRefetchEffect: UseFocusRefetchEffect
   const { useFeature, useFeatures } = createFeatureHooks(useClient, useQuery)
 
   return {
-    SupaProvider,
+    SupashipProvider,
     useClient,
     useFeatureContext,
     useFeature,

--- a/packages/react-core/src/feature-hooks.ts
+++ b/packages/react-core/src/feature-hooks.ts
@@ -1,4 +1,9 @@
-import type { FeatureContext, FeatureValue, Features, SupaClient } from '@supashiphq/javascript-sdk'
+import type {
+  FeatureContext,
+  FeatureValue,
+  Features,
+  SupashipClient,
+} from '@supashiphq/javascript-sdk'
 import type { QueryState, QueryKey, UseQueryOptions } from './query-hooks-factory'
 
 /** Narrow SDK feature definition `{ value: T }` to `T`; otherwise {@link FeatureValue}. */
@@ -26,7 +31,7 @@ export type UseQueryHook = <TData = unknown, TError = Error>(
 /** @internal */
 export type UseClientHook = <
   TFeatures extends Features<Record<string, FeatureValue>>,
->() => SupaClient<TFeatures>
+>() => SupashipClient<TFeatures>
 
 const FEATURE_STALE_MS = 5 * 60 * 1000
 const FEATURE_CACHE_MS = 10 * 60 * 1000

--- a/packages/react-core/src/index.ts
+++ b/packages/react-core/src/index.ts
@@ -1,5 +1,5 @@
 export { createSupashipReact } from './create-supaship-react'
-export type { SupaGenericFeatures } from './create-supaship-react'
+export type { SupashipGenericFeatures } from './create-supaship-react'
 export { useWebFocusRefetchEffect } from './focus-web'
 export { createQueryHooks, getInitialQueryState } from './query-hooks-factory'
 export type {

--- a/packages/react-native/README.md
+++ b/packages/react-native/README.md
@@ -13,7 +13,7 @@ npm install @supashiphq/react-native-sdk
 ## Quick start
 
 ```tsx
-import { SupaProvider, useFeature, FeaturesWithFallbacks } from '@supashiphq/react-native-sdk'
+import { SupashipProvider, useFeature, FeaturesWithFallbacks } from '@supashiphq/react-native-sdk'
 import { View, Text } from 'react-native'
 
 const features = {
@@ -23,7 +23,7 @@ const features = {
 
 export function App() {
   return (
-    <SupaProvider
+    <SupashipProvider
       config={{
         sdkKey: 'your-sdk-key',
         environment: 'production',
@@ -33,7 +33,7 @@ export function App() {
       }}
     >
       <Home />
-    </SupaProvider>
+    </SupashipProvider>
   )
 }
 
@@ -82,15 +82,15 @@ function Dashboard() {
 }
 ```
 
-### Declarative boolean gate (`SupaFeature`)
+### Declarative boolean gate (`SupashipFeature`)
 
 ```tsx
-import { SupaFeature } from '@supashiphq/react-native-sdk'
+import { SupashipFeature } from '@supashiphq/react-native-sdk'
 import { View, Text } from 'react-native'
 
 function Header() {
   return (
-    <SupaFeature
+    <SupashipFeature
       feature="new-header"
       loading={<Text>…</Text>}
       variations={{
@@ -153,7 +153,7 @@ If you set `sensitiveContextProperties`, hashing uses Web Crypto where available
 
 ## Unit testing in your app
 
-Same idea as the React SDK: wrap in **`SupaProvider`** with test `config` and **`toolbar={false}`**, then `render` your screen.
+Same idea as the React SDK: wrap in **`SupashipProvider`** with test `config` and **`toolbar={false}`**, then `render` your screen.
 
 If Jest resolves `react-native` from this package’s internals, add a tiny stub so tests do not need the full native binary:
 

--- a/packages/react-native/src/__tests__/SupashipProvider.test.tsx
+++ b/packages/react-native/src/__tests__/SupashipProvider.test.tsx
@@ -1,14 +1,14 @@
 import React from 'react'
 import { render } from '@testing-library/react'
-import { SupaProvider, useClient, useFeatureContext } from '../supaship'
-import { SupaClient, FeaturesWithFallbacks } from '@supashiphq/javascript-sdk'
+import { SupashipProvider, useClient, useFeatureContext } from '../supaship'
+import { SupashipClient, FeaturesWithFallbacks } from '@supashiphq/javascript-sdk'
 import { jest, describe, it, expect } from '@jest/globals'
 
 const mockUpdateContext = jest.fn()
 const mockGetContext = jest.fn()
 const mockGetFeatureFallback = jest.fn()
 jest.mock('@supashiphq/javascript-sdk', () => ({
-  SupaClient: jest.fn().mockImplementation(() => ({
+  SupashipClient: jest.fn().mockImplementation(() => ({
     getFeature: jest.fn(),
     getFeatureFallback: mockGetFeatureFallback,
     updateContext: mockUpdateContext,
@@ -19,7 +19,7 @@ jest.mock('@supashiphq/javascript-sdk', () => ({
   })),
 }))
 
-describe('SupaProvider', () => {
+describe('SupashipProvider', () => {
   const config = {
     baseUrl: 'https://api.test.com',
     sdkKey: 'test-sdk-key',
@@ -34,12 +34,12 @@ describe('SupaProvider', () => {
 
   it('should initialize client with config', () => {
     render(
-      <SupaProvider config={config} toolbar={false}>
+      <SupashipProvider config={config} toolbar={false}>
         <div>Test</div>
-      </SupaProvider>
+      </SupashipProvider>
     )
 
-    expect(SupaClient).toHaveBeenCalledWith({
+    expect(SupashipClient).toHaveBeenCalledWith({
       ...config,
       toolbar: false,
     })
@@ -47,12 +47,12 @@ describe('SupaProvider', () => {
 
   it('should initialize client with default toolbar configuration', () => {
     render(
-      <SupaProvider config={config}>
+      <SupashipProvider config={config}>
         <div>Test</div>
-      </SupaProvider>
+      </SupashipProvider>
     )
 
-    expect(SupaClient).toHaveBeenCalledWith(
+    expect(SupashipClient).toHaveBeenCalledWith(
       expect.objectContaining({
         ...config,
         toolbar: expect.objectContaining({ onOverrideChange: expect.any(Function) }),
@@ -71,7 +71,7 @@ describe('SupaProvider', () => {
     }
 
     const { container } = render(<TestComponent />)
-    expect(container.textContent).toContain('useClient must be used within a SupaProvider')
+    expect(container.textContent).toContain('useClient must be used within a SupashipProvider')
   })
 
   it('should show error when useFeatureContext is used outside provider', () => {
@@ -85,7 +85,9 @@ describe('SupaProvider', () => {
     }
 
     const { container } = render(<TestComponent />)
-    expect(container.textContent).toContain('useFeatureContext must be used within a SupaProvider')
+    expect(container.textContent).toContain(
+      'useFeatureContext must be used within a SupashipProvider'
+    )
   })
 
   it('should provide context update functionality', () => {
@@ -113,9 +115,9 @@ describe('SupaProvider', () => {
     }
 
     const { getByTestId } = render(
-      <SupaProvider config={config} toolbar={false}>
+      <SupashipProvider config={config} toolbar={false}>
         <TestComponent />
-      </SupaProvider>
+      </SupashipProvider>
     )
 
     getByTestId('update-context').click()

--- a/packages/react-native/src/__tests__/query.test.tsx
+++ b/packages/react-native/src/__tests__/query.test.tsx
@@ -3,7 +3,7 @@ import { useQuery, queryCache } from '../supaship'
 import { jest, describe, it, expect, beforeEach } from '@jest/globals'
 
 jest.mock('@supashiphq/javascript-sdk', () => ({
-  SupaClient: jest.fn().mockImplementation(() => ({
+  SupashipClient: jest.fn().mockImplementation(() => ({
     getFeatures: jest.fn(),
   })),
 }))

--- a/packages/react-native/src/__tests__/useFeature.test.tsx
+++ b/packages/react-native/src/__tests__/useFeature.test.tsx
@@ -2,7 +2,7 @@ import React from 'react'
 import { render, screen, act } from '@testing-library/react'
 import '@testing-library/jest-dom'
 import { useFeature } from '../hooks'
-import { SupaProvider } from '../supaship'
+import { SupashipProvider } from '../supaship'
 import { FeatureValue, FeatureContext, FeaturesWithFallbacks } from '@supashiphq/javascript-sdk'
 import { jest, describe, it, expect, beforeEach } from '@jest/globals'
 
@@ -21,7 +21,7 @@ const mockGetFeatureFallback = jest.fn(
   (key: string) => testFeatures[key as keyof typeof testFeatures]
 )
 jest.mock('@supashiphq/javascript-sdk', () => ({
-  SupaClient: jest.fn().mockImplementation(() => ({
+  SupashipClient: jest.fn().mockImplementation(() => ({
     getFeature: mockGetFeature,
     getFeatureFallback: mockGetFeatureFallback,
     updateContext: jest.fn(),
@@ -73,9 +73,9 @@ describe('useFeature', () => {
     mockGetFeature.mockReturnValueOnce(promise)
 
     render(
-      <SupaProvider config={config}>
+      <SupashipProvider config={config}>
         <TestComponent featureKey="test-feature" />
-      </SupaProvider>
+      </SupashipProvider>
     )
 
     expect(screen.getByTestId('feature-data').textContent).toBe('true')
@@ -100,9 +100,9 @@ describe('useFeature', () => {
     mockGetFeature.mockReturnValueOnce(promise)
 
     render(
-      <SupaProvider config={config}>
+      <SupashipProvider config={config}>
         <TestComponent featureKey="other-feature" />
-      </SupaProvider>
+      </SupashipProvider>
     )
 
     await act(async () => {
@@ -122,9 +122,9 @@ describe('useFeature', () => {
     mockGetFeature.mockReturnValueOnce(promise)
 
     render(
-      <SupaProvider config={config}>
+      <SupashipProvider config={config}>
         <TestComponent featureKey="test-feature" options={{ context }} />
-      </SupaProvider>
+      </SupashipProvider>
     )
 
     await act(async () => {
@@ -137,9 +137,9 @@ describe('useFeature', () => {
 
   it('should not fetch when shouldFetch is false', async () => {
     render(
-      <SupaProvider config={config}>
+      <SupashipProvider config={config}>
         <TestComponent featureKey="test-feature" options={{ shouldFetch: false }} />
-      </SupaProvider>
+      </SupashipProvider>
     )
 
     expect(mockGetFeature).not.toHaveBeenCalled()

--- a/packages/react-native/src/components.tsx
+++ b/packages/react-native/src/components.tsx
@@ -3,7 +3,7 @@ import { useFeature } from './hooks'
 import { FeatureKey, FeatureContext } from './types'
 import { hasValue } from './utils'
 
-export interface SupaFeatureProps {
+export interface SupashipFeatureProps {
   /**
    * The feature flag key to evaluate
    */
@@ -38,7 +38,7 @@ export interface SupaFeatureProps {
  *
  * @example
  * ```tsx
- * <SupaFeature
+ * <SupashipFeature
  *   feature="new-header"
  *   loading={<ActivityIndicator />}
  *   variations={{
@@ -48,13 +48,13 @@ export interface SupaFeatureProps {
  * />
  * ```
  */
-export function SupaFeature({
+export function SupashipFeature({
   feature,
   context,
   shouldFetch = true,
   variations,
   loading,
-}: SupaFeatureProps): React.JSX.Element | null {
+}: SupashipFeatureProps): React.JSX.Element | null {
   const { feature: featureValue, isLoading } = useFeature(feature, {
     context,
     shouldFetch,

--- a/packages/react-native/src/index.ts
+++ b/packages/react-native/src/index.ts
@@ -1,5 +1,5 @@
 export {
-  SupaProvider,
+  SupashipProvider,
   useClient,
   useFeatureContext,
   useQuery,

--- a/packages/react-native/src/supaship.ts
+++ b/packages/react-native/src/supaship.ts
@@ -4,7 +4,7 @@ import { useNativeFocusRefetchEffect } from '@supashiphq/react-core/focus-native
 const supaship = createSupashipReact(useNativeFocusRefetchEffect)
 
 export const {
-  SupaProvider,
+  SupashipProvider,
   useClient,
   useFeatureContext,
   useQuery,

--- a/packages/react-native/src/types.ts
+++ b/packages/react-native/src/types.ts
@@ -8,12 +8,12 @@ import type { QueryState } from '@supashiphq/react-core'
 export type { UseFeatureResult, UseFeaturesResult } from '@supashiphq/react-core'
 
 export type {
-  SupaClientConfig as SupaProviderConfig,
-  SupaPlugin,
+  SupashipClientConfig as SupashipProviderConfig,
+  SupashipPlugin,
   FeatureValue,
   FeatureContext,
-  SupaToolbarPluginConfig,
-  SupaToolbarPosition,
+  SupashipToolbarPluginConfig,
+  SupashipToolbarPosition,
 } from '@supashiphq/javascript-sdk'
 
 /**

--- a/packages/react/README.md
+++ b/packages/react/README.md
@@ -15,7 +15,7 @@ pnpm add @supashiphq/react-sdk
 ## Quick Start
 
 ```tsx
-import { SupaProvider, useFeature, FeaturesWithFallbacks } from '@supashiphq/react-sdk'
+import { SupashipProvider, useFeature, FeaturesWithFallbacks } from '@supashiphq/react-sdk'
 
 // Define your features with type safety
 const features = {
@@ -26,7 +26,7 @@ const features = {
 
 function App() {
   return (
-    <SupaProvider
+    <SupashipProvider
       config={{
         sdkKey: 'your-sdk-key',
         environment: 'production',
@@ -38,7 +38,7 @@ function App() {
       }}
     >
       <YourApp />
-    </SupaProvider>
+    </SupashipProvider>
   )
 }
 
@@ -95,22 +95,22 @@ function MyComponent() {
 
 ## API Reference
 
-### SupaProvider
+### SupashipProvider
 
 The provider component that makes feature flags available to your React component tree.
 
 ```tsx
-<SupaProvider config={config}>{children}</SupaProvider>
+<SupashipProvider config={config}>{children}</SupashipProvider>
 ```
 
 **Props:**
 
-| Prop       | Type               | Required | Description                  |
-| ---------- | ------------------ | -------- | ---------------------------- |
-| `config`   | `SupaClientConfig` | Yes      | Configuration for the client |
-| `children` | `React.ReactNode`  | Yes      | Child components             |
-| `plugins`  | `SupaPlugin[]`     | No       | Custom plugins               |
-| `toolbar`  | `ToolbarConfig`    | No       | Development toolbar settings |
+| Prop       | Type                   | Required | Description                  |
+| ---------- | ---------------------- | -------- | ---------------------------- |
+| `config`   | `SupashipClientConfig` | Yes      | Configuration for the client |
+| `children` | `React.ReactNode`      | Yes      | Child components             |
+| `plugins`  | `SupashipPlugin[]`     | No       | Custom plugins               |
+| `toolbar`  | `ToolbarConfig`        | No       | Development toolbar settings |
 
 **Configuration Options:**
 
@@ -298,12 +298,12 @@ function FeatureList() {
 }
 ```
 
-### SupaFeature Component
+### SupashipFeature Component
 
 A declarative component for rendering different UI based on boolean feature flag values.
 
 ```tsx
-<SupaFeature
+<SupashipFeature
   feature="feature-name"
   loading={<Skeleton />}
   variations={{
@@ -330,7 +330,7 @@ A declarative component for rendering different UI based on boolean feature flag
 // Simple boolean feature flag
 function Header() {
   return (
-    <SupaFeature
+    <SupashipFeature
       feature="new-header"
       loading={<HeaderSkeleton />}
       variations={{
@@ -346,7 +346,7 @@ function UserDashboard() {
   const { user } = useAuth()
 
   return (
-    <SupaFeature
+    <SupashipFeature
       feature="beta-dashboard"
       context={{ userId: user.id, plan: user.plan }}
       variations={{
@@ -391,7 +391,7 @@ function UserProfileSettings() {
 
 ### useClient Hook
 
-Access the underlying SupaClient instance for advanced use cases.
+Access the underlying SupashipClient instance for advanced use cases.
 
 ```tsx
 const client = useClient()
@@ -455,7 +455,7 @@ function App() {
   const { user } = useAuth()
 
   return (
-    <SupaProvider
+    <SupashipProvider
       config={{
         sdkKey: 'your-sdk-key',
         features: FEATURE_FLAGS,
@@ -468,7 +468,7 @@ function App() {
       }}
     >
       <YourApp />
-    </SupaProvider>
+    </SupashipProvider>
   )
 }
 ```
@@ -530,7 +530,7 @@ function UserDashboard() {
 ```tsx
 // app/providers.tsx
 'use client'
-import { SupaProvider, FeaturesWithFallbacks } from '@supashiphq/react-sdk'
+import { SupashipProvider, FeaturesWithFallbacks } from '@supashiphq/react-sdk'
 
 const FEATURE_FLAGS = {
   'new-hero': false,
@@ -539,7 +539,7 @@ const FEATURE_FLAGS = {
 
 export function Providers({ children }: { children: React.ReactNode }) {
   return (
-    <SupaProvider
+    <SupashipProvider
       config={{
         sdkKey: process.env.NEXT_PUBLIC_SUPASHIP_SDK_KEY!,
         environment: process.env.NODE_ENV!,
@@ -547,7 +547,7 @@ export function Providers({ children }: { children: React.ReactNode }) {
       }}
     >
       {children}
-    </SupaProvider>
+    </SupashipProvider>
   )
 }
 
@@ -579,7 +579,7 @@ export default function HomePage() {
 
 ```tsx
 // pages/_app.tsx
-import { SupaProvider, FeaturesWithFallbacks } from '@supashiphq/react-sdk'
+import { SupashipProvider, FeaturesWithFallbacks } from '@supashiphq/react-sdk'
 import type { AppProps } from 'next/app'
 
 const FEATURE_FLAGS = {
@@ -588,7 +588,7 @@ const FEATURE_FLAGS = {
 
 export default function App({ Component, pageProps }: AppProps) {
   return (
-    <SupaProvider
+    <SupashipProvider
       config={{
         sdkKey: process.env.NEXT_PUBLIC_SUPASHIP_SDK_KEY!,
         environment: process.env.NODE_ENV!,
@@ -596,7 +596,7 @@ export default function App({ Component, pageProps }: AppProps) {
       }}
     >
       <Component {...pageProps} />
-    </SupaProvider>
+    </SupashipProvider>
   )
 }
 ```
@@ -605,7 +605,7 @@ export default function App({ Component, pageProps }: AppProps) {
 
 ```tsx
 // src/main.tsx or src/index.tsx
-import { SupaProvider, FeaturesWithFallbacks } from '@supashiphq/react-sdk'
+import { SupashipProvider, FeaturesWithFallbacks } from '@supashiphq/react-sdk'
 
 const FEATURE_FLAGS = {
   'new-ui': false,
@@ -614,7 +614,7 @@ const FEATURE_FLAGS = {
 
 function App() {
   return (
-    <SupaProvider
+    <SupashipProvider
       config={{
         sdkKey: import.meta.env.VITE_SUPASHIP_SDK_KEY, // Vite
         // or
@@ -624,7 +624,7 @@ function App() {
       }}
     >
       <YourApp />
-    </SupaProvider>
+    </SupashipProvider>
   )
 }
 ```
@@ -634,7 +634,7 @@ function App() {
 The SDK includes a development toolbar for testing and debugging feature flags locally.
 
 ```tsx
-<SupaProvider
+<SupashipProvider
   config={{ ... }}
   toolbar={{
     enabled: 'auto', // 'auto' | 'always' | 'never'
@@ -642,7 +642,7 @@ The SDK includes a development toolbar for testing and debugging feature flags l
   }}
 >
   <YourApp />
-</SupaProvider>
+</SupashipProvider>
 ```
 
 - `'auto'`: Shows toolbar in development environments only (default)
@@ -662,11 +662,11 @@ The toolbar allows you to:
 
 ```tsx
 // test-utils/providers.tsx
-import { SupaProvider, FeaturesWithFallbacks } from '@supashiphq/react-sdk'
+import { SupashipProvider, FeaturesWithFallbacks } from '@supashiphq/react-sdk'
 
 export function TestProviders({ children, features = {} as FeaturesWithFallbacks }) {
   return (
-    <SupaProvider
+    <SupashipProvider
       config={{
         sdkKey: 'test-key',
         environment: 'test',
@@ -675,7 +675,7 @@ export function TestProviders({ children, features = {} as FeaturesWithFallbacks
       }}
     >
       {children}
-    </SupaProvider>
+    </SupashipProvider>
   )
 }
 ```
@@ -738,18 +738,18 @@ const features: FeaturesWithFallbacks = {
 #### Provider Not Found Error
 
 ```
-Error: useFeature must be used within a SupaProvider
+Error: useFeature must be used within a SupashipProvider
 ```
 
-**Solution:** Ensure your component is wrapped in a `SupaProvider`:
+**Solution:** Ensure your component is wrapped in a `SupashipProvider`:
 
 ```tsx
 // ✅ Correct
 function App() {
   return (
-    <SupaProvider config={{ ... }}>
+    <SupashipProvider config={{ ... }}>
       <MyComponent />
-    </SupaProvider>
+    </SupashipProvider>
   )
 }
 

--- a/packages/react/src/__tests__/SupashipProvider.test.tsx
+++ b/packages/react/src/__tests__/SupashipProvider.test.tsx
@@ -1,15 +1,15 @@
 import React from 'react'
 import { render } from '@testing-library/react'
-import { SupaProvider, useClient, useFeatureContext } from '../supaship'
-import { SupaClient, FeaturesWithFallbacks } from '@supashiphq/javascript-sdk'
+import { SupashipProvider, useClient, useFeatureContext } from '../supaship'
+import { SupashipClient, FeaturesWithFallbacks } from '@supashiphq/javascript-sdk'
 import { jest, describe, it, expect } from '@jest/globals'
 
-// Mock the SupaClient
+// Mock the SupashipClient
 const mockUpdateContext = jest.fn()
 const mockGetContext = jest.fn()
 const mockGetFeatureFallback = jest.fn()
 jest.mock('@supashiphq/javascript-sdk', () => ({
-  SupaClient: jest.fn().mockImplementation(() => ({
+  SupashipClient: jest.fn().mockImplementation(() => ({
     getFeature: jest.fn(),
     getFeatureFallback: mockGetFeatureFallback,
     updateContext: mockUpdateContext,
@@ -20,7 +20,7 @@ jest.mock('@supashiphq/javascript-sdk', () => ({
   })),
 }))
 
-describe('SupaProvider', () => {
+describe('SupashipProvider', () => {
   const config = {
     baseUrl: 'https://api.test.com',
     sdkKey: 'test-sdk-key',
@@ -35,12 +35,12 @@ describe('SupaProvider', () => {
 
   it('should initialize client with config', () => {
     render(
-      <SupaProvider config={config} toolbar={false}>
+      <SupashipProvider config={config} toolbar={false}>
         <div>Test</div>
-      </SupaProvider>
+      </SupashipProvider>
     )
 
-    expect(SupaClient).toHaveBeenCalledWith({
+    expect(SupashipClient).toHaveBeenCalledWith({
       ...config,
       toolbar: false,
     })
@@ -48,12 +48,12 @@ describe('SupaProvider', () => {
 
   it('should initialize client with default toolbar configuration', () => {
     render(
-      <SupaProvider config={config}>
+      <SupashipProvider config={config}>
         <div>Test</div>
-      </SupaProvider>
+      </SupashipProvider>
     )
 
-    expect(SupaClient).toHaveBeenCalledWith(
+    expect(SupashipClient).toHaveBeenCalledWith(
       expect.objectContaining({
         ...config,
         toolbar: expect.objectContaining({ onOverrideChange: expect.any(Function) }),
@@ -72,7 +72,7 @@ describe('SupaProvider', () => {
     }
 
     const { container } = render(<TestComponent />)
-    expect(container.textContent).toContain('useClient must be used within a SupaProvider')
+    expect(container.textContent).toContain('useClient must be used within a SupashipProvider')
   })
 
   it('should show error when useFeatureContext is used outside provider', () => {
@@ -86,7 +86,9 @@ describe('SupaProvider', () => {
     }
 
     const { container } = render(<TestComponent />)
-    expect(container.textContent).toContain('useFeatureContext must be used within a SupaProvider')
+    expect(container.textContent).toContain(
+      'useFeatureContext must be used within a SupashipProvider'
+    )
   })
 
   it('should provide context update functionality', () => {
@@ -114,9 +116,9 @@ describe('SupaProvider', () => {
     }
 
     const { getByTestId } = render(
-      <SupaProvider config={config} toolbar={false}>
+      <SupashipProvider config={config} toolbar={false}>
         <TestComponent />
-      </SupaProvider>
+      </SupashipProvider>
     )
 
     // Simulate updating context

--- a/packages/react/src/__tests__/query.test.tsx
+++ b/packages/react/src/__tests__/query.test.tsx
@@ -2,9 +2,9 @@ import { renderHook, act, waitFor } from '@testing-library/react'
 import { useQuery, queryCache } from '../supaship'
 import { jest, describe, it, expect, beforeEach } from '@jest/globals'
 
-// Mock the SupaClient
+// Mock the SupashipClient
 jest.mock('@supashiphq/javascript-sdk', () => ({
-  SupaClient: jest.fn().mockImplementation(() => ({
+  SupashipClient: jest.fn().mockImplementation(() => ({
     getFeatures: jest.fn(),
   })),
 }))

--- a/packages/react/src/__tests__/useFeature.test.tsx
+++ b/packages/react/src/__tests__/useFeature.test.tsx
@@ -2,7 +2,7 @@ import React from 'react'
 import { render, screen, act } from '@testing-library/react'
 import '@testing-library/jest-dom'
 import { useFeature } from '../hooks'
-import { SupaProvider } from '../supaship'
+import { SupashipProvider } from '../supaship'
 import { FeatureValue, FeatureContext, FeaturesWithFallbacks } from '@supashiphq/javascript-sdk'
 import { jest, describe, it, expect, beforeEach } from '@jest/globals'
 
@@ -17,13 +17,13 @@ const testFeatures = {
   'other-feature': false,
 }
 
-// Mock the SupaClient
+// Mock the SupashipClient
 const mockGetFeature = jest.fn<GetFeatureFn>()
 const mockGetFeatureFallback = jest.fn(
   (key: string) => testFeatures[key as keyof typeof testFeatures]
 )
 jest.mock('@supashiphq/javascript-sdk', () => ({
-  SupaClient: jest.fn().mockImplementation(() => ({
+  SupashipClient: jest.fn().mockImplementation(() => ({
     getFeature: mockGetFeature,
     getFeatureFallback: mockGetFeatureFallback,
     updateContext: jest.fn(),
@@ -75,9 +75,9 @@ describe('useFeature', () => {
     mockGetFeature.mockReturnValueOnce(promise)
 
     render(
-      <SupaProvider config={config}>
+      <SupashipProvider config={config}>
         <TestComponent featureKey="test-feature" />
-      </SupaProvider>
+      </SupashipProvider>
     )
 
     // Initial state should show fallback value from feature definitions while loading
@@ -105,9 +105,9 @@ describe('useFeature', () => {
     mockGetFeature.mockReturnValueOnce(promise)
 
     render(
-      <SupaProvider config={config}>
+      <SupashipProvider config={config}>
         <TestComponent featureKey="other-feature" />
-      </SupaProvider>
+      </SupashipProvider>
     )
 
     await act(async () => {
@@ -128,9 +128,9 @@ describe('useFeature', () => {
     mockGetFeature.mockReturnValueOnce(promise)
 
     render(
-      <SupaProvider config={config}>
+      <SupashipProvider config={config}>
         <TestComponent featureKey="test-feature" options={{ context }} />
-      </SupaProvider>
+      </SupashipProvider>
     )
 
     await act(async () => {
@@ -143,9 +143,9 @@ describe('useFeature', () => {
 
   it('should not fetch when shouldFetch is false', async () => {
     render(
-      <SupaProvider config={config}>
+      <SupashipProvider config={config}>
         <TestComponent featureKey="test-feature" options={{ shouldFetch: false }} />
-      </SupaProvider>
+      </SupashipProvider>
     )
 
     expect(mockGetFeature).not.toHaveBeenCalled()

--- a/packages/react/src/components.tsx
+++ b/packages/react/src/components.tsx
@@ -5,7 +5,7 @@ import { useFeature } from './hooks'
 import { FeatureKey, FeatureContext } from './types'
 import { hasValue } from './utils'
 
-export interface SupaFeatureProps {
+export interface SupashipFeatureProps {
   /**
    * The feature flag key to evaluate
    */
@@ -36,12 +36,12 @@ export interface SupaFeatureProps {
 }
 
 /**
- * SupaFeature component that conditionally renders variations based on feature flag values.
+ * SupashipFeature component that conditionally renders variations based on feature flag values.
  * Uses the default value defined in the client configuration.
  *
  * @example
  * ```tsx
- * <SupaFeature
+ * <SupashipFeature
  *   feature="new-header"
  *   loading={<HeaderSkeleton />}
  *   variations={{
@@ -51,13 +51,13 @@ export interface SupaFeatureProps {
  * />
  * ```
  */
-export function SupaFeature({
+export function SupashipFeature({
   feature,
   context,
   shouldFetch = true,
   variations,
   loading,
-}: SupaFeatureProps): React.JSX.Element | null {
+}: SupashipFeatureProps): React.JSX.Element | null {
   const { feature: featureValue, isLoading } = useFeature(feature, {
     context,
     shouldFetch,

--- a/packages/react/src/index.ts
+++ b/packages/react/src/index.ts
@@ -1,7 +1,7 @@
 'use client'
 
 export {
-  SupaProvider,
+  SupashipProvider,
   useClient,
   useFeatureContext,
   useQuery,

--- a/packages/react/src/supaship.ts
+++ b/packages/react/src/supaship.ts
@@ -5,7 +5,7 @@ import { createSupashipReact, useWebFocusRefetchEffect } from '@supashiphq/react
 const supaship = createSupashipReact(useWebFocusRefetchEffect)
 
 export const {
-  SupaProvider,
+  SupashipProvider,
   useClient,
   useFeatureContext,
   useQuery,

--- a/packages/react/src/types.ts
+++ b/packages/react/src/types.ts
@@ -8,12 +8,12 @@ import type { QueryState } from '@supashiphq/react-core'
 export type { UseFeatureResult, UseFeaturesResult } from '@supashiphq/react-core'
 
 export type {
-  SupaClientConfig as SupaProviderConfig,
-  SupaPlugin,
+  SupashipClientConfig as SupashipProviderConfig,
+  SupashipPlugin,
   FeatureValue,
   FeatureContext,
-  SupaToolbarPluginConfig,
-  SupaToolbarPosition,
+  SupashipToolbarPluginConfig,
+  SupashipToolbarPosition,
 } from '@supashiphq/javascript-sdk'
 
 /**

--- a/packages/vue/README.md
+++ b/packages/vue/README.md
@@ -89,10 +89,10 @@ app.mount('#app')
 
 **Options:**
 
-| Option    | Type               | Required | Description                  |
-| --------- | ------------------ | -------- | ---------------------------- |
-| `config`  | `SupaClientConfig` | Yes      | Configuration for the client |
-| `toolbar` | `ToolbarConfig`    | No       | Development toolbar settings |
+| Option    | Type                   | Required | Description                  |
+| --------- | ---------------------- | -------- | ---------------------------- |
+| `config`  | `SupashipClientConfig` | Yes      | Configuration for the client |
+| `toolbar` | `ToolbarConfig`        | No       | Development toolbar settings |
 
 **Configuration Options:**
 
@@ -635,7 +635,7 @@ it('renders the banner', () => {
 })
 ```
 
-`useFeature` / `useFeatures` work inside that tree. For **plain functions** that take a `SupaClient`, use `new SupaClient(...)` and mock `fetch` like the JavaScript SDK example if you want no network.
+`useFeature` / `useFeatures` work inside that tree. For **plain functions** that take a `SupashipClient`, use `new SupashipClient(...)` and mock `fetch` like the JavaScript SDK example if you want no network.
 
 ## Troubleshooting
 

--- a/packages/vue/src/__tests__/useFeature.test.ts
+++ b/packages/vue/src/__tests__/useFeature.test.ts
@@ -5,12 +5,12 @@ import { useFeature } from '../composables'
 import { createSupaship } from '../plugin'
 import { FeatureContext, FeaturesWithFallbacks } from '@supashiphq/javascript-sdk'
 
-// Mock the SupaClient
+// Mock the SupashipClient
 vi.mock('@supashiphq/javascript-sdk', async () => {
   const actual = await vi.importActual('@supashiphq/javascript-sdk')
   return {
     ...actual,
-    SupaClient: vi.fn().mockImplementation(() => ({
+    SupashipClient: vi.fn().mockImplementation(() => ({
       getFeature: vi.fn(),
       getFeatureFallback: vi.fn((key: string) => testFeatures[key as keyof typeof testFeatures]),
       updateContext: vi.fn(),
@@ -101,9 +101,9 @@ describe('useFeature', () => {
     const plugin = createSupaship({ config })
     const mockGetFeature = vi.fn()
 
-    // Get the mocked SupaClient instance
-    const { SupaClient } = await import('@supashiphq/javascript-sdk')
-    const mockedSupaClient = SupaClient as unknown as {
+    // Get the mocked SupashipClient instance
+    const { SupashipClient } = await import('@supashiphq/javascript-sdk')
+    const mockedSupashipClient = SupashipClient as unknown as {
       mockImplementation: (
         fn: () => {
           getFeature: typeof mockGetFeature
@@ -113,7 +113,7 @@ describe('useFeature', () => {
         }
       ) => void
     }
-    mockedSupaClient.mockImplementation(() => ({
+    mockedSupashipClient.mockImplementation(() => ({
       getFeature: mockGetFeature,
       getFeatureFallback: vi.fn((key: string) => testFeatures[key as keyof typeof testFeatures]),
       updateContext: vi.fn(),

--- a/packages/vue/src/plugin.ts
+++ b/packages/vue/src/plugin.ts
@@ -1,41 +1,41 @@
 import { App, Plugin, inject, InjectionKey } from 'vue'
 import {
-  SupaClient,
-  SupaClientConfig,
+  SupashipClient,
+  SupashipClientConfig,
   FeatureContext,
   FeatureValue,
   FeaturesWithFallbacks,
-  SupaToolbarOverrideChange,
-  SupaToolbarPluginConfig,
+  SupashipToolbarOverrideChange,
+  SupashipToolbarPluginConfig,
 } from '@supashiphq/javascript-sdk'
 import { useQueryClient } from './query'
 
 export type SupashipVuePluginConfig<
   TFeatures extends FeaturesWithFallbacks = FeaturesWithFallbacks,
-> = Omit<SupaClientConfig, 'plugins' | 'toolbar' | 'features'> & {
+> = Omit<SupashipClientConfig, 'plugins' | 'toolbar' | 'features'> & {
   features: TFeatures
 }
 
-export interface SupaContextValue<TFeatures extends FeaturesWithFallbacks> {
-  client: SupaClient<TFeatures>
+export interface SupashipContextValue<TFeatures extends FeaturesWithFallbacks> {
+  client: SupashipClient<TFeatures>
   features: TFeatures
   updateContext: (context: FeatureContext, mergeWithExisting?: boolean) => void
   getContext: () => FeatureContext | undefined
 }
 
 // Injection key for Vue's provide/inject
-const SupashipContextKey: InjectionKey<SupaContextValue<FeaturesWithFallbacks>> =
+const SupashipContextKey: InjectionKey<SupashipContextValue<FeaturesWithFallbacks>> =
   Symbol('SupashipContext')
 
 export interface SupashipVuePluginOptions<
   TFeatures extends FeaturesWithFallbacks = FeaturesWithFallbacks,
 > {
   config: SupashipVuePluginConfig<TFeatures>
-  toolbar?: SupaToolbarPluginConfig | boolean
+  toolbar?: SupashipToolbarPluginConfig | boolean
 }
 
 // Default toolbar config (stable reference)
-const DEFAULT_TOOLBAR_CONFIG: SupaToolbarPluginConfig = { enabled: 'auto' }
+const DEFAULT_TOOLBAR_CONFIG: SupashipToolbarPluginConfig = { enabled: 'auto' }
 
 /**
  * Creates a Vue plugin for Supaship
@@ -56,7 +56,7 @@ export function createSupaship<TFeatures extends FeaturesWithFallbacks>(
 
       // Stable callback for toolbar override changes
       const handleOverrideChange = (
-        featureOverride: SupaToolbarOverrideChange,
+        featureOverride: SupashipToolbarOverrideChange,
         allOverrides: Record<string, FeatureValue>
       ): void => {
         // Call user's onOverrideChange if provided
@@ -89,7 +89,7 @@ export function createSupaship<TFeatures extends FeaturesWithFallbacks>(
               onOverrideChange: handleOverrideChange,
             }
 
-      const client = new SupaClient<TFeatures>({
+      const client = new SupashipClient<TFeatures>({
         ...config,
         toolbar: toolbarConfig,
       })
@@ -102,7 +102,7 @@ export function createSupaship<TFeatures extends FeaturesWithFallbacks>(
         return client.getContext()
       }
 
-      const contextValue: SupaContextValue<TFeatures> = {
+      const contextValue: SupashipContextValue<TFeatures> = {
         client,
         features: config.features,
         updateContext,
@@ -110,7 +110,7 @@ export function createSupaship<TFeatures extends FeaturesWithFallbacks>(
       }
 
       // Provide the context to the app with features type preserved
-      app.provide(SupashipContextKey, contextValue as SupaContextValue<TFeatures>)
+      app.provide(SupashipContextKey, contextValue as SupashipContextValue<TFeatures>)
 
       // Cleanup on app unmount
       app.config.globalProperties.$supaship = client
@@ -125,7 +125,7 @@ export function createSupaship<TFeatures extends FeaturesWithFallbacks>(
  * Composable to access the Supaship client
  * The features type will be inferred from the createSupaship config
  */
-export function useClient(): SupaClient<FeaturesWithFallbacks> {
+export function useClient(): SupashipClient<FeaturesWithFallbacks> {
   const context = inject(SupashipContextKey)
   if (!context) {
     throw new Error(

--- a/packages/vue/src/types.ts
+++ b/packages/vue/src/types.ts
@@ -6,11 +6,11 @@ import type {
 } from '@supashiphq/javascript-sdk'
 
 export type {
-  SupaPlugin,
+  SupashipPlugin,
   FeatureValue,
   FeatureContext,
-  SupaToolbarPluginConfig,
-  SupaToolbarPosition,
+  SupashipToolbarPluginConfig,
+  SupashipToolbarPosition,
 } from '@supashiphq/javascript-sdk'
 
 /**


### PR DESCRIPTION
To avoid any brand confusion, rename the prefix Supa to Supaship.